### PR TITLE
fix: enabled change order items functionality

### DIFF
--- a/Save/Management/ManagementViewController.swift
+++ b/Save/Management/ManagementViewController.swift
@@ -140,10 +140,7 @@ class ManagementViewController: BaseTableViewController, UploadCellDelegate {
     }
 
     override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        if indexPath.section == 0 {
-            return false
-        }
-
+        
         switch getUpload(indexPath)?.state {
         case .pending, .paused:
             return true


### PR DESCRIPTION
Tap the edit icon in the navigation bar, then rearrange the items by dragging and dropping them into the desired order